### PR TITLE
 fix(curriculum): amend challenge wording to ensure passing test

### DIFF
--- a/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/6476f7a4827bcc61682f2347.md
+++ b/curriculum/challenges/english/14-responsive-web-design-22/learn-intermediate-css-by-building-a-cat-painting/6476f7a4827bcc61682f2347.md
@@ -9,7 +9,7 @@ dashedName: step-11
 
 The next position property is `absolute`. When you use the `absolute` value for your `position` property, the element is taken out of the normal flow of the document, and then its position is determined by the `top`, `right`, `bottom`, and `left` properties.
 
-Set the position property of your `.cat-head` element to `absolute`, then set `top` and `left` properties to any pixel value.
+Set the position property of your `.cat-head` element to `absolute`, then set `top` and `left` properties to any positive pixel value.
 
 <!-- **Note**: You can experiment with `top`, `left`, `bottom`, and `right` properties here, but the test would only pass for `top` of `300px`, and left of `400px`. -->
 


### PR DESCRIPTION
Challenge states:
"Set the position property of your .cat-head element to absolute, then set top and left properties to any pixel value." 

Observation:
Entering a negative value for the left property will prevent test passing.  A negative value is valid for the left property and should be permitted.  It may be preferrable in this case, to simply limit the range of acceptable values in the challenge by including the word "positive".  This would eliminate the need to write tests for "rare" side cases.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
